### PR TITLE
Adds in kawase_clear (for those edge cases)

### DIFF
--- a/kawase.yyp
+++ b/kawase.yyp
@@ -39,6 +39,14 @@
             }
         },
         {
+            "Key": "0fba3a4a-13bb-4cc6-b85e-b028b78df637",
+            "Value": {
+                "id": "84cc3e7c-b609-4e2e-94ec-9d616401161e",
+                "resourcePath": "scripts\\kawase_clear\\kawase_clear.yy",
+                "resourceType": "GMScript"
+            }
+        },
+        {
             "Key": "1ab2772c-a5c5-48f9-a38b-3737567f68b0",
             "Value": {
                 "id": "24d36bec-6387-422b-83b6-2712fec9a7e9",
@@ -392,7 +400,8 @@
         "7a98a3ee-6373-4781-944b-7f13abe28c0a",
         "6747987d-e44b-4aee-bfa7-e6b976346939",
         "7a7235c6-c78d-4987-b267-29f4ac921ca1",
-        "70cdcf9d-0543-4201-a652-db7f2fb82f36"
+        "70cdcf9d-0543-4201-a652-db7f2fb82f36",
+        "0fba3a4a-13bb-4cc6-b85e-b028b78df637"
     ],
     "tutorial": ""
 }

--- a/scripts/kawase_clear/kawase_clear.gml
+++ b/scripts/kawase_clear/kawase_clear.gml
@@ -1,0 +1,24 @@
+/* 
+    |\__/,|   (`\
+  _.|o o  |_   ) )
+-(((---(((--------
+Cat Judges your code
+*/
+
+/// @func kawase_clear(kawase_array)
+/// @description Clears all of the kawase surfaces (may not be necessary)
+/// @param kawase_array
+var _root_array = argument0;
+var _iterations = kawase_get_max_iterations(_root_array);
+
+var _i = 0;
+repeat(_iterations + 1)
+{
+	__kawase_check_surface(_root_array[_i]);
+	var _current_array = _root_array[_i];
+	surface_set_target(_current_array[2]);
+	draw_clear_alpha(c_black, 0);
+	surface_reset_target();
+	   
+	++_i;
+}

--- a/scripts/kawase_clear/kawase_clear.yy
+++ b/scripts/kawase_clear/kawase_clear.yy
@@ -1,0 +1,8 @@
+{
+    "id": "0fba3a4a-13bb-4cc6-b85e-b028b78df637",
+    "modelName": "GMScript",
+    "mvc": "1.0",
+    "name": "kawase_clear",
+    "IsCompatibility": false,
+    "IsDnD": false
+}

--- a/views/587ded97-1fde-4c5a-97ac-27cab5440097.yy
+++ b/views/587ded97-1fde-4c5a-97ac-27cab5440097.yy
@@ -12,7 +12,8 @@
         "7a98a3ee-6373-4781-944b-7f13abe28c0a",
         "6747987d-e44b-4aee-bfa7-e6b976346939",
         "7a7235c6-c78d-4987-b267-29f4ac921ca1",
-        "70cdcf9d-0543-4201-a652-db7f2fb82f36"
+        "70cdcf9d-0543-4201-a652-db7f2fb82f36",
+        "0fba3a4a-13bb-4cc6-b85e-b028b78df637"
     ],
     "filterType": "GMScript",
     "folderName": "Kawase",

--- a/views/bb7005c9-e3b1-4d95-8573-2d272d149a16.yy
+++ b/views/bb7005c9-e3b1-4d95-8573-2d272d149a16.yy
@@ -5,7 +5,6 @@
     "name": "bb7005c9-e3b1-4d95-8573-2d272d149a16",
     "children": [
         "ed6a955d-5826-4f98-a450-10b414266c27",
-        "3a5af38c-757d-41ae-98c0-5d4b09e14e6a",
         "a9188620-a624-4a5a-83ae-a1b53faf038b",
         "f418569b-3bdd-4706-a0e4-364317f54032",
         "a128950b-5063-4876-b4a6-b99dbd2ea6d1",
@@ -13,10 +12,7 @@
         "e42bf5cc-3f46-4d67-a6d0-a4885a11ac3f",
         "75ac291e-7061-4bcb-8e8a-3b3545332d41",
         "cc98d028-7bdd-4680-85f3-c87a7baa481e",
-        "8427047f-9ef8-4c77-89f3-9c20623d07b6",
-        "f85efd3d-bcec-4ec0-8226-da808afda79d",
-        "3a5af38c-757d-44ae-98c0-5d4b09e14e6a",
-        "7e093a2a-e51c-4a1e-9a53-f9080d38730b"
+        "8427047f-9ef8-4c77-89f3-9c20623d07b6"
     ],
     "filterType": "GMOptions",
     "folderName": "options",


### PR DESCRIPTION
Kawase itself works fantastically. But there was a very odd issue that I've realized that happened while working on a game project. The blur effect seems to stack on top of one another, which caused some serious artifacts (Sprites with cut out holes for masking was what I noticed with) And I've realized that kawase doesn't cleanup afterwards. (That being, the surfaces don't get cleared so the blur can work from a blank canvas)

While this may or may not be intentional, I've gone with the route of making a function in the game project I was working on to handle this edge case. As most probably don't suffer from this issue, and I'd rather not break someone elses project. And then  backported it to 2.2.5. 

How it works: By calling `kawase_clear(kawase_array)`, it clears all of kawases surfaces. Ready to be used with `kawase_blur` again.

